### PR TITLE
Adding optional imagePullSecrets for private repositories.

### DIFF
--- a/charts/argo-cronjob/templates/argo-cronjob.yaml
+++ b/charts/argo-cronjob/templates/argo-cronjob.yaml
@@ -98,3 +98,9 @@ spec:
 {{ toYaml . | indent 12 }}
 {{- end -}}
 {{- end }}
+
+# This is our image pull secret references, if we have image pull secrets
+{{- with .Values.image.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml . | indent 6 }}
+{{- end }}

--- a/charts/argo-cronjob/values.yaml
+++ b/charts/argo-cronjob/values.yaml
@@ -41,6 +41,14 @@ image:
   args: []
   # Image pull policy: IfNotPresent / Always
   imagePullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## imagePullSecrets:
+  ##   - name: myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
 
 # Environment variables (for globals, all deployments)
 globalEnvs: []

--- a/charts/cronjob-multi/templates/cronjob-multi.yaml
+++ b/charts/cronjob-multi/templates/cronjob-multi.yaml
@@ -172,3 +172,9 @@ spec:
 {{- end }}
 ---
 {{- end }}
+
+# This is our image pull secret references, if we have image pull secrets
+{{- with .Values.image.imagePullSecrets }}
+          imagePullSecrets:
+{{ toYaml . | indent 12 }}
+{{- end }}

--- a/charts/cronjob-multi/values.yaml
+++ b/charts/cronjob-multi/values.yaml
@@ -58,6 +58,14 @@ image:
   args: []
   # Image pull policy: IfNotPresent / Always
   imagePullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## imagePullSecrets:
+  ##   - name: myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
 
 # Additional pod annotations
 podAnnotations: {}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -161,3 +161,9 @@ spec:
 {{- if or (eq .Values.serviceAccount.enabled true) (eq .Values.rbac.create true) }}
           serviceAccountName: {{ template "name" . }}
 {{- end }}
+
+# This is our image pull secret references, if we have image pull secrets
+{{- with .Values.image.imagePullSecrets }}
+          imagePullSecrets:
+{{ toYaml . | indent 12 }}
+{{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -51,6 +51,14 @@ image:
   args: []
   # Image pull policy: IfNotPresent / Always
   imagePullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## imagePullSecrets:
+  ##   - name: myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
 
 # Additional pod annotations
 podAnnotations: {}

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -374,3 +374,9 @@ SORRY for this mess, this is needed because of the above
 {{- if or (eq .Values.serviceAccount.enabled true) (eq .Values.rbac.create true) }}
       serviceAccountName: {{ template "name" . }}
 {{- end }}
+
+# This is our image pull secret references, if we have image pull secrets
+{{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -28,6 +28,14 @@ image:
   args: []
   # Image pull policy: IfNotPresent / Always
   imagePullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## imagePullSecrets:
+  ##   - name: myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
 
 # Ingress definitions
 ingress:

--- a/charts/statefulset/templates/statefulset.yaml
+++ b/charts/statefulset/templates/statefulset.yaml
@@ -380,6 +380,12 @@ SORRY for this mess, this is needed because of the above
       serviceAccountName: {{ template "name" . }}
 {{- end }}
 
+# This is our image pull secret references, if we have image pull secrets
+{{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+{{- end }}
+
 {{- if .Values.persistence.enabled }}
   # If we have persistence enabled, lets set it up
   volumeClaimTemplates:

--- a/charts/statefulset/values.yaml
+++ b/charts/statefulset/values.yaml
@@ -28,6 +28,14 @@ image:
   args: []
   # Image pull policy: IfNotPresent / Always
   imagePullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## imagePullSecrets:
+  ##   - name: myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
 
 # Ingress definitions
 ingress:


### PR DESCRIPTION
I didn't test the template, but this should work.

This adds support for adding imagePullSecrets in case of using a private repository.

Secrets must be manually added to kubernetes.

```bash
kubectl create secret docker-registry regcred --docker-server=privaterepo.com --docker-username='somerobotaccount' --docker-password=$ROBOTK8S_TOKEN
```

ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

Example usage:
```yaml
image:
  imagePullSecrets:
    - name: myRegistryKeySecretName
```