### PR TITLE
Updating Api version for Ingress

### DIFF
--- a/templates/ingress-secondary.yaml
+++ b/templates/ingress-secondary.yaml
@@ -4,7 +4,7 @@
 # Author/Maintainer: Farley <farley@neonsurge.com>
 ################################################
 {{- $fullName := include "name" . }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   # Old without template override: name: {{ template "name" . }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -4,7 +4,7 @@
 # Author/Maintainer: Farley <farley@neonsurge.com>
 ################################################
 {{- $fullName := include "name" . }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   # Old without template override: name: {{ template "name" . }}


### PR DESCRIPTION
I have updated the version of the Ingress API in Kubernetes to make it compatible with version 1.21 and 1.22. I tried it on a 1.22 cluster and it works

According to the official documentation that is the correct api
https://v1-21.docs.kubernetes.io/docs/concepts/services-networking/ingress/
https://v1-22.docs.kubernetes.io/docs/concepts/services-networking/ingress/