### PR TITLE
Add support for http probe scheme

### DIFF
--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -238,6 +238,7 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
 {{- if eq .Values.livenessProbe.probeType "httpGet" }}
             httpGet:
+              scheme: {{ .Values.livenessProbe.scheme }}
               path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.livenessProbe.port }}
 {{- else if eq .Values.livenessProbe.probeType "tcpSocket" }}
@@ -262,6 +263,7 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- if eq .Values.readinessProbe.probeType "httpGet" }}
             httpGet:
+              scheme: {{ .Values.readinessProbe.scheme }}
               path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.readinessProbe.port }}
 {{- else if eq .Values.readinessProbe.probeType "tcpSocket" }}

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -137,12 +137,13 @@ livenessProbe:
   failureThreshold: 3
 
   # Specify either httpGet, tcpSocket or exec
-  # httpGet uses path and port (below)
+  # httpGet uses scheme, path and port (below)
   # tcpSocket uses port (below)
   # exec uses command (below)
   probeType: httpGet
 
   # parameters for probes
+  scheme: HTTP
   path: /alive
   port: default-service
   command:
@@ -159,12 +160,13 @@ readinessProbe:
   failureThreshold: 2
 
   # Specify either httpGet, tcpSocket or exec
-  # httpGet uses path and port (below)
+  # httpGet uses scheme, path and port (below)
   # tcpSocket uses port (below)
   # exec uses command (below)
   probeType: httpGet
 
   # parameters for probes
+  scheme: HTTP
   path: /ready
   port: default-service
   command:

--- a/charts/statefulset/templates/statefulset.yaml
+++ b/charts/statefulset/templates/statefulset.yaml
@@ -237,6 +237,7 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
 {{- if eq .Values.livenessProbe.probeType "httpGet" }}
             httpGet:
+              scheme: {{ .Values.livenessProbe.scheme }}
               path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.livenessProbe.port }}
 {{- else if eq .Values.livenessProbe.probeType "tcpSocket" }}
@@ -261,6 +262,7 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- if eq .Values.readinessProbe.probeType "httpGet" }}
             httpGet:
+              scheme: {{ .Values.readinessProbe.scheme }}
               path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.readinessProbe.port }}
 {{- else if eq .Values.readinessProbe.probeType "tcpSocket" }}

--- a/charts/statefulset/values.yaml
+++ b/charts/statefulset/values.yaml
@@ -120,12 +120,13 @@ livenessProbe:
   failureThreshold: 3
 
   # Specify either httpGet, tcpSocket or exec
-  # httpGet uses path and port (below)
+  # httpGet uses scheme, path and port (below)
   # tcpSocket uses port (below)
   # exec uses command (below)
   probeType: httpGet
 
   # parameters for probes
+  scheme: HTTP
   path: /alive
   port: default-service
   command:
@@ -141,12 +142,13 @@ readinessProbe:
   failureThreshold: 2
 
   # Specify either httpGet, tcpSocket or exec
-  # httpGet uses path and port (below)
+  # httpGet uses scheme, path and port (below)
   # tcpSocket uses port (below)
   # exec uses command (below)
   probeType: httpGet
 
   # parameters for probes
+  scheme: HTTP
   path: /ready
   port: default-service
   command:


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes
> [HTTP probes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#httpgetaction-v1-core) have additional fields that can be set on httpGet:
>
> scheme: Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to "HTTP".