### PR TITLE
Switch container memory env vars from kibibytes to megabytes

### DIFF
--- a/charts/argo-cronjob/templates/argo-cronjob.yaml
+++ b/charts/argo-cronjob/templates/argo-cronjob.yaml
@@ -101,16 +101,29 @@ spec:
                 resourceFieldRef:
                   resource: limits.cpu
                   divisor: 1m
+{{- if .Values.usingMemoryKibiBytesEnvs }}
             - name: CONTAINER_MEMORY_REQUESTS_KIBIBYTES
               valueFrom:
                 resourceFieldRef:
-                  resource: limits.memory
+                  resource: requests.memory
                   divisor: 1Ki
             - name: CONTAINER_MEMORY_LIMITS_KIBIBYTES
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: 1Ki
+{{- else }}
+            - name: CONTAINER_MEMORY_REQUESTS_MEGABYTES
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.memory
+                  divisor: 1Mi
+            - name: CONTAINER_MEMORY_LIMITS_MEGABYTES
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: 1Mi
+{{- end }}
 
             # Global variables placed in a "global" values file for all environments
             {{- if .Values.globalEnvs }}

--- a/charts/argo-cronjob/values.yaml
+++ b/charts/argo-cronjob/values.yaml
@@ -64,6 +64,9 @@ labelsEnableDefault: true
 # A way to pull secondary env variables from configmaps and secrets
 envFrom: []
 
+# This enables the deprecated memory kibibytes env variables for backwards compatibility. TODO: Remove from future release.
+usingMemoryKibiBytesEnvs: false
+
 # container resource requests/limits
 # this is set VERY low by default, to be aggressive above resource limiting, please override this if necessary
 # Note: Limits are HARD Limits

--- a/charts/cronjob-multi/templates/cronjob-multi.yaml
+++ b/charts/cronjob-multi/templates/cronjob-multi.yaml
@@ -155,16 +155,29 @@ spec:
                     resourceFieldRef:
                       resource: limits.cpu
                       divisor: 1m
+{{- if .Values.usingMemoryKibiBytesEnvs }}
                 - name: CONTAINER_MEMORY_REQUESTS_KIBIBYTES
                   valueFrom:
                     resourceFieldRef:
-                      resource: limits.memory
+                      resource: requests.memory
                       divisor: 1Ki
                 - name: CONTAINER_MEMORY_LIMITS_KIBIBYTES
                   valueFrom:
                     resourceFieldRef:
                       resource: limits.memory
                       divisor: 1Ki
+{{- else }}
+                - name: CONTAINER_MEMORY_REQUESTS_MEGABYTES
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: requests.memory
+                      divisor: 1Mi
+                - name: CONTAINER_MEMORY_LIMITS_MEGABYTES
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                      divisor: 1Mi
+{{- end }}
 
                 # Global variables placed in a "global" values file for all environments
                 {{- if $toplevel.Values.globalEnvs }}

--- a/charts/cronjob-multi/values.yaml
+++ b/charts/cronjob-multi/values.yaml
@@ -85,6 +85,9 @@ labelsEnableDefault: true
 # A way to pull secondary env variables from configmaps and secrets
 envFrom: []
 
+# This enables the deprecated memory kibibytes env variables for backwards compatibility. TODO: Remove from future release.
+usingMemoryKibiBytesEnvs: false
+
 # Lower the ndots value, to reduce the search path expansion of DNS queries
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config
 dnsConfig:

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -146,16 +146,29 @@ spec:
                     resourceFieldRef:
                       resource: limits.cpu
                       divisor: 1m
+{{- if .Values.usingMemoryKibiBytesEnvs }}
                 - name: CONTAINER_MEMORY_REQUESTS_KIBIBYTES
                   valueFrom:
                     resourceFieldRef:
-                      resource: limits.memory
+                      resource: requests.memory
                       divisor: 1Ki
                 - name: CONTAINER_MEMORY_LIMITS_KIBIBYTES
                   valueFrom:
                     resourceFieldRef:
                       resource: limits.memory
                       divisor: 1Ki
+{{- else }}
+                - name: CONTAINER_MEMORY_REQUESTS_MEGABYTES
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: requests.memory
+                      divisor: 1Mi
+                - name: CONTAINER_MEMORY_LIMITS_MEGABYTES
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                      divisor: 1Mi
+{{- end }}
 
                 # Global variables placed in a "global" values file for all environments
                 {{- if .Values.globalEnvs }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -78,6 +78,9 @@ labelsEnableDefault: true
 # A way to pull secondary env variables from configmaps and secrets
 envFrom: []
 
+# This enables the deprecated memory kibibytes env variables for backwards compatibility. TODO: Remove from future release.
+usingMemoryKibiBytesEnvs: false
+
 # Adjust the DNS configuration of your pods
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config
 dnsConfig:

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -174,17 +174,29 @@ spec:
                 resourceFieldRef:
                   resource: limits.cpu
                   divisor: 1m
+{{- if .Values.usingMemoryKibiBytesEnvs }}
             - name: CONTAINER_MEMORY_REQUESTS_KIBIBYTES
               valueFrom:
                 resourceFieldRef:
-                  resource: limits.memory
+                  resource: requests.memory
                   divisor: 1Ki
             - name: CONTAINER_MEMORY_LIMITS_KIBIBYTES
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: 1Ki
-
+{{- else }}
+            - name: CONTAINER_MEMORY_REQUESTS_MEGABYTES
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.memory
+                  divisor: 1Mi
+            - name: CONTAINER_MEMORY_LIMITS_MEGABYTES
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: 1Mi
+{{- end }}
 
             # Insert globals here, special handling so we can "tpl" these values and use eg: namespace in them
             {{- range .Values.globalEnvs }}

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -126,6 +126,9 @@ extraEnvs: []
 # A way to pull secondary env variables from configmaps and secrets
 envFrom: []
 
+# This enables the deprecated memory kibibytes env variables for backwards compatibility. TODO: Remove from future release.
+usingMemoryKibiBytesEnvs: false
+
 # livenessProbes are used to determine when to restart a container
 livenessProbe:
   enabled: true

--- a/charts/statefulset/templates/statefulset.yaml
+++ b/charts/statefulset/templates/statefulset.yaml
@@ -174,16 +174,29 @@ spec:
                 resourceFieldRef:
                   resource: limits.cpu
                   divisor: 1m
+{{- if .Values.usingMemoryKibiBytesEnvs }}
             - name: CONTAINER_MEMORY_REQUESTS_KIBIBYTES
               valueFrom:
                 resourceFieldRef:
-                  resource: limits.memory
+                  resource: requests.memory
                   divisor: 1Ki
             - name: CONTAINER_MEMORY_LIMITS_KIBIBYTES
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: 1Ki
+{{- else }}
+            - name: CONTAINER_MEMORY_REQUESTS_MEGABYTES
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.memory
+                  divisor: 1Mi
+            - name: CONTAINER_MEMORY_LIMITS_MEGABYTES
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: 1Mi
+{{- end }}
 
             # Insert globals here, special handling so we can "tpl" these values and use eg: namespace in them
             {{- range .Values.globalEnvs }}

--- a/charts/statefulset/values.yaml
+++ b/charts/statefulset/values.yaml
@@ -109,6 +109,9 @@ extraEnvs: []
 # A way to pull secondary env variables from configmaps and secrets
 envFrom: []
 
+# This enables the deprecated memory kibibytes env variables for backwards compatibility. TODO: Remove from future release.
+usingMemoryKibiBytesEnvs: false
+
 # livenessProbes are used to determine when to restart a container
 livenessProbe:
   enabled: true


### PR DESCRIPTION
* MegaBytes are more intuitive/useful units than KibiBytes
* Also fixes resource reference for `CONTAINER_MEMORY_REQUESTS_KIBIBYTES`
