### PR TITLE
Support defining the cronjob 'suspend' spec

### DIFF
--- a/charts/cronjob-multi/templates/cronjob-multi.yaml
+++ b/charts/cronjob-multi/templates/cronjob-multi.yaml
@@ -19,6 +19,9 @@ spec:
   successfulJobsHistoryLimit: {{ default 1 $toplevel.Values.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ default 3 $toplevel.Values.failedJobsHistoryLimit }}
   startingDeadlineSeconds: {{ default 600 $toplevel.Values.startingDeadlineSeconds }}
+  {{- if $toplevel.Values.suspend }}
+  suspend: {{ $toplevel.Values.suspend }}
+  {{- end }}
   jobTemplate:
     metadata:
       name: {{ $job.name | quote }}

--- a/charts/cronjob-multi/values.yaml
+++ b/charts/cronjob-multi/values.yaml
@@ -46,6 +46,9 @@ parallelism: 1
 # How many to run in parallel, don't use this unless you know what you're doing
 completions: 1
 
+# Whether to create in the suspended state, null for backwards compatibility
+suspend: null
+
 # Image repository location (override if needed)
 image:
   # Which image to release (NOTE: ONLY SPECIFY IF YOU ARE DEPLOYING EXTERNALLY, eg from dockerhub)

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
   successfulJobsHistoryLimit: {{ default 1 .Values.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ default 3 .Values.failedJobsHistoryLimit }}
   startingDeadlineSeconds: {{ default 600 .Values.startingDeadlineSeconds }}
+  suspend: {{ default false .Values.suspend }}
   jobTemplate:
     metadata:
       name: {{ template "name" . }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -14,7 +14,9 @@ spec:
   successfulJobsHistoryLimit: {{ default 1 .Values.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ default 3 .Values.failedJobsHistoryLimit }}
   startingDeadlineSeconds: {{ default 600 .Values.startingDeadlineSeconds }}
-  suspend: {{ default false .Values.suspend }}
+  {{- if .Values.suspend }}
+  suspend: {{ .Values.suspend }}
+  {{- end }}
   jobTemplate:
     metadata:
       name: {{ template "name" . }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -39,6 +39,9 @@ parallelism: 1
 # How many to run in parallel, don't use this unless you know what you're doing
 completions: 1
 
+# Whether to create in the suspended state, defaults to false
+suspend: false
+
 # Image repository location (override if needed)
 image:
   # Which image to release (NOTE: ONLY SPECIFY IF YOU ARE DEPLOYING EXTERNALLY, eg from dockerhub)

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -39,8 +39,8 @@ parallelism: 1
 # How many to run in parallel, don't use this unless you know what you're doing
 completions: 1
 
-# Whether to create in the suspended state, defaults to false
-suspend: false
+# Whether to create in the suspended state, null for backwards compatibility
+suspend: null
 
 # Image repository location (override if needed)
 image:


### PR DESCRIPTION
Useful in the rare cases where you wish to create a cronjob that defaults to suspended.