### PR TITLE
Support templating ingress annotations

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -28,9 +28,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
 {{- end }}
-  {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+{{ with .Values.ingress.annotations -}}
+  {{ tpl ( toYaml .) $ | indent 4 }}
+{{- end }}
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}


### PR DESCRIPTION
Allow ingress annotations to be templated 

From this
```
    annotations:
      nginx.ingress.kubernetes.io/auth-url: "http://ext-auth/auth-request"
      nginx.ingress.kubernetes.io/auth-snippet: |
        proxy_set_header "X-OpenApi-URL" "http://service/swagger.json?v={{ template "get-release-tag" . }}";
      nginx.ingress.kubernetes.io/auth-response-headers: authorization
```

To this
```
    nginx.ingress.kubernetes.io/auth-response-headers: authorization
    nginx.ingress.kubernetes.io/auth-snippet: |
      proxy_set_header "X-OpenApi-URL" "http://service/swagger.json/swagger.json?v=2.11.0";
    nginx.ingress.kubernetes.io/auth-url: http://ext-auth/auth-request
```