### PR TITLE
Support templating service annotations

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -13,11 +13,11 @@ metadata:
   annotations:
     # Our service annotations (old method, backwards compatability)
 {{- with .Values.serviceAnnotations }}
-{{ toYaml . | indent 4 }}
+{{ tpl ( toYaml .) $ | indent 4 }}
 {{- end }}
     # Our service annotations (new)
 {{- with .Values.service.annotations }}
-{{ toYaml . | indent 4 }}
+{{ tpl ( toYaml .) $ | indent 4 }}
 {{- end }}
 
   # include labels for this service to identify it


### PR DESCRIPTION
Allow service annotations to be templated

From this
```
  # Location of OpenAPI specification
  service:
    annotations:
      openapi.io/url: http://service/.well-known/openapi.json?v={{ template "get-release-tag" . }}
```

To this
```
  # Location of OpenAPI specification
  service:
    annotations:
      openapi.io/url: https://service/.well-known/openapi.json?v=2.5.0
```